### PR TITLE
Added small changes in template config and values file to support google out of the box

### DIFF
--- a/charts/dex/templates/_dex_config.yaml.tpl
+++ b/charts/dex/templates/_dex_config.yaml.tpl
@@ -21,6 +21,7 @@ grpc:
 {{- end }}
 connectors:
 {{- range $id, $connector := .Values.connectors }}
+{{- if ( $connector.config.clientID ) and ( $connector.config.clientSecret ) }}
 - type: {{ $connector.config.type }}
   id: {{ $id }}
   name: {{ $connector.config.name }}
@@ -28,9 +29,15 @@ connectors:
     clientID: {{ $connector.config.clientID }}
     clientSecret: {{ $connector.config.clientSecret }}
     redirectURI: https://{{ $issuerDomain }}/callback
+{{- if $connector.config.issuer }}
+    issuer: {{ $connector.config.issuer }}
+{{- end }}
+{{- if $connector.config.orgs }}
     orgs:
 {{- range $connector.config.orgs }}
       - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 oauth2:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -86,3 +86,11 @@ connectors:
       clientID:
       clientSecret:
       orgs:
+  google:
+    config:
+      type: oidc
+      name: Google
+      clientID:
+      clientSecret:
+      issuer:
+ 


### PR DESCRIPTION
Maybe it is can be useful for somebody who want use google auth. The way it worked before also works.
Helm Install string is:
helm install --debug   --namespace jx  --timeout 600  --set domain="dex.jexample.com" --set connectors.github.config.clientID="githubclientid" --set connectors.github.config.clientSecret="gihubclientsecret" --set connectors.github.config.orgs={yourorganization} --set connectors.google.config.clientID="googleaccountid"   --set connectors.google.config.clientSecret="googleaccountsecret" --set connectors.google.config.issuer="https://accounts.google.com" --name=jx-sso-dex .