### PR TITLE
Don't show the "Login with email" prompt.

### DIFF
--- a/charts/dex/templates/_dex_config.yaml.tpl
+++ b/charts/dex/templates/_dex_config.yaml.tpl
@@ -36,7 +36,7 @@ connectors:
 oauth2:
   skipApprovalScreen: true
 
-enablePasswordDB: true
+enablePasswordDB: false
 
 frontend:
   theme: cloudbees


### PR DESCRIPTION
It's not used, and by presenting the user with only one option, this selection screen gets skipped and login is transparent.

@ccojocar 