### PR TITLE
optionally use login rather than ID for GitHub

### DIFF
--- a/Documentation/connectors/github.md
+++ b/Documentation/connectors/github.md
@@ -69,7 +69,7 @@ connectors:
     teamNameField: slug
     # flag which will switch from using the internal GitHub id to the users handle (@mention) as the user id.
     # It is possible for a user to change their own user name but it is very rare for them to do so
-    useLoginAsId: false
+    useLoginAsID: false
 ```
 
 ## GitHub Enterprise

--- a/Documentation/connectors/github.md
+++ b/Documentation/connectors/github.md
@@ -67,6 +67,9 @@ connectors:
     #   - ['acme:site-reliability-engineers'] for 'slug'
     #   - ['acme:Site Reliability Engineers', 'acme:site-reliability-engineers'] for 'both'
     teamNameField: slug
+    # flag which will switch from using the internal GitHub id to the users handle (@mention) as the user id.
+    # It is possible for a user to change their own user name but it is very rare for them to do so
+    useLoginAsId: false
 ```
 
 ## GitHub Enterprise

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -48,7 +48,7 @@ type Config struct {
 	RootCA        string `json:"rootCA"`
 	TeamNameField string `json:"teamNameField"`
 	LoadAllGroups bool   `json:"loadAllGroups"`
-	UseLoginAsId  bool   `json:"useLoginAsId"`
+	UseLoginAsID  bool   `json:"useLoginAsID"`
 }
 
 // Org holds org-team filters, in which teams are optional.
@@ -84,7 +84,7 @@ func (c *Config) Open(id string, logger logrus.FieldLogger) (connector.Connector
 		clientSecret: c.ClientSecret,
 		apiURL:       apiURL,
 		logger:       logger,
-		useLoginAsId: c.UseLoginAsId,
+		useLoginAsID: c.UseLoginAsID,
 	}
 
 	if c.HostName != "" {
@@ -151,7 +151,7 @@ type githubConnector struct {
 	// if set to true and no orgs are configured then connector loads all user claims (all orgs and team)
 	loadAllGroups bool
 	// if set to true will use the users handle rather than their numeric id as the ID
-	useLoginAsId bool
+	useLoginAsID bool
 }
 
 // groupsRequired returns whether dex requires GitHub's 'read:org' scope. Dex
@@ -271,7 +271,7 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 		Email:         user.Email,
 		EmailVerified: true,
 	}
-	if c.useLoginAsId {
+	if c.useLoginAsID {
 		identity.UserID = user.Login
 	}
 

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -275,7 +275,6 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 		identity.UserID = user.Login
 	}
 
-
 	// Only set identity.Groups if 'orgs', 'org', or 'groups' scope are specified.
 	if c.groupsRequired(s.Groups) {
 		groups, err := c.getGroups(ctx, client, s.Groups, user.Login)

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -192,7 +192,7 @@ func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 	req, err := http.NewRequest("GET", hostURL.String(), nil)
 	expectNil(t, err)
 
-	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), useLoginAsId: true}
+	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), useLoginAsID: true}
 	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
 
 	expectNil(t, err)

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -124,10 +124,11 @@ func TestUserGroupsWithTeamNameAndSlugFieldConfig(t *testing.T) {
 	})
 }
 
+// tests that the users login is used as their username when they have no username set
 func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 
 	s := newTestServer(map[string]testResponse{
-		"/user": {data: user{Login: "some-login"}},
+		"/user": {data: user{Login: "some-login", ID: 12345678}},
 		"/user/emails": {data: []userEmail{{
 			Email:    "some@email.com",
 			Verified: true,
@@ -154,6 +155,7 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some-login")
+	expectEquals(t, identity.UserID, "12345678")
 	expectEquals(t, 0, len(identity.Groups))
 
 	c = githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), loadAllGroups: true}
@@ -161,8 +163,42 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 
 	expectNil(t, err)
 	expectEquals(t, identity.Username, "some-login")
+	expectEquals(t, identity.UserID, "12345678")
 	expectEquals(t, identity.Groups, []string{"org-1"})
+}
 
+
+func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
+
+	s := newTestServer(map[string]testResponse{
+		"/user": {data: user{Login: "some-login", ID: 12345678, Name:"Joe Bloggs"}},
+		"/user/emails": {data: []userEmail{{
+			Email:    "some@email.com",
+			Verified: true,
+			Primary:  true,
+		}}},
+		"/login/oauth/access_token": {data: map[string]interface{}{
+			"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
+			"expires_in":   "30",
+		}},
+		"/user/orgs": {
+			data: []org{{Login: "org-1"}},
+		},
+	})
+	defer s.Close()
+
+	hostURL, err := url.Parse(s.URL)
+	expectNil(t, err)
+
+	req, err := http.NewRequest("GET", hostURL.String(), nil)
+	expectNil(t, err)
+
+	c := githubConnector{apiURL: s.URL, hostName: hostURL.Host, httpClient: newClient(), useLoginAsId: true}
+	identity, err := c.HandleCallback(connector.Scopes{Groups: true}, req)
+
+	expectNil(t, err)
+	expectEquals(t, identity.UserID, "some-login")
+	expectEquals(t, identity.Username, "Joe Bloggs")
 }
 
 func newTestServer(responses map[string]testResponse) *httptest.Server {

--- a/connector/github/github_test.go
+++ b/connector/github/github_test.go
@@ -167,11 +167,10 @@ func TestUsernameIncludedInFederatedIdentity(t *testing.T) {
 	expectEquals(t, identity.Groups, []string{"org-1"})
 }
 
-
 func TestLoginUsedAsIDWhenConfigured(t *testing.T) {
 
 	s := newTestServer(map[string]testResponse{
-		"/user": {data: user{Login: "some-login", ID: 12345678, Name:"Joe Bloggs"}},
+		"/user": {data: user{Login: "some-login", ID: 12345678, Name: "Joe Bloggs"}},
 		"/user/emails": {data: []userEmail{{
 			Email:    "some@email.com",
 			Verified: true,


### PR DESCRIPTION
Allow an option to use the github user handle rather than an id.

For downstream apps using a github handle is much simpler than working with numbers.

Whilst the number is stable and the handle is not - GitHUb does give you a big scary wanring if you try and change it that bad things may happen to you, and generally few users ever change it.

This can be enabled with a configuration option `useLoginAsId`