### PR TITLE
feat(login) use github logins not IDs as the underlying id

### DIFF
--- a/charts/dex/templates/_dex_config.yaml.tpl
+++ b/charts/dex/templates/_dex_config.yaml.tpl
@@ -32,7 +32,7 @@ connectors:
 {{- range $connector.config.orgs }}
       - name: {{ . }}
 {{- end }}
-{{- if eq connector.config.type "github" }}
+{{- if eq $connector.config.type "github" }}
    useLoginAsID: true
 {{- end }}
 {{- end }}

--- a/charts/dex/templates/_dex_config.yaml.tpl
+++ b/charts/dex/templates/_dex_config.yaml.tpl
@@ -32,6 +32,9 @@ connectors:
 {{- range $connector.config.orgs }}
       - name: {{ . }}
 {{- end }}
+{{- if eq connector.config.type "github" }}
+   useLoginAsID: true
+{{- end }}
 {{- end }}
 oauth2:
   skipApprovalScreen: true


### PR DESCRIPTION
configure `useLoginAsID: true` for github connectors that we get
predictable usernames that match the login.

ref
https://github.com/dexidp/dex/pull/1396/files#diff-9b235bc0eab9721a279726cc8410bb81R72