### PR TITLE
Fix indention in the template

### DIFF
--- a/charts/dex/templates/_dex_config.yaml.tpl
+++ b/charts/dex/templates/_dex_config.yaml.tpl
@@ -33,7 +33,7 @@ connectors:
       - name: {{ . }}
 {{- end }}
 {{- if eq $connector.config.type "github" }}
-   useLoginAsID: true
+    useLoginAsID: true
 {{- end }}
 {{- end }}
 oauth2:


### PR DESCRIPTION
I broke the template by using an incorrect amount of space that I did
not see when I initiailly inspected the generated output.