### PR TITLE
fix: supporting newer cert-manager api version

### DIFF
--- a/charts/dex/templates/cert-grpc-server.yaml
+++ b/charts/dex/templates/cert-grpc-server.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.certs.grpc.create }}
 {{ $fullname := include "fullname" . }}
+{{- if .Values.certs.newApi }}
+apiVersion: cert-manager.io/v1alpha2
+{{- else }}
 apiVersion: certmanager.k8s.io/v1alpha1
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ $fullname }}-grpc-server-cert

--- a/charts/dex/templates/issuer-grpc-ca.yaml
+++ b/charts/dex/templates/issuer-grpc-ca.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.certs.grpc.create }}
 {{ $fullname := include "fullname" . }}
+{{- if .Values.certs.newApi }}
+apiVersion: cert-manager.io/v1alpha2
+{{- else }}
 apiVersion: certmanager.k8s.io/v1alpha1
+{{- end }}
 kind: Issuer
 metadata:
   name: dex-grpc-cert-issuer

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -49,6 +49,7 @@ terminationGracePeriodSeconds: 10
 nodeSelector: {}
 
 certs:
+  newApi: false
   imagePullPolicy: "IfNotPresent"
   grpc:
     create: true


### PR DESCRIPTION
To use Jenkins X on EKS, the cert-manager needs to be the newest version to allow it to utilise IAM roles for DNS changes through the kubernetes service account.
The new cert-manager updated the API from `certmanager.k8s.io/v1alpha1` to `cert-manager.io/v1alpha2`. See https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/

With the additions in this PR this becomes configurable and I can tell it to use the new API through the app settings in my jenkins-x configuration.
It should also allow Jenkins X core devs to support EKS out of the box eventually.