### PR TITLE
fix: turn on cert manager v1alpha2 by default

### DIFF
--- a/charts/dex/templates/cert-grpc-server.yaml
+++ b/charts/dex/templates/cert-grpc-server.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.certs.grpc.create }}
 {{ $fullname := include "fullname" . }}
-{{- if .Values.certs.newApi }}
-apiVersion: cert-manager.io/v1alpha2
-{{- else }}
+{{- if .Values.certs.legacyApi }}
 apiVersion: certmanager.k8s.io/v1alpha1
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
 {{- end }}
 kind: Certificate
 metadata:

--- a/charts/dex/templates/issuer-grpc-ca.yaml
+++ b/charts/dex/templates/issuer-grpc-ca.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.certs.grpc.create }}
 {{ $fullname := include "fullname" . }}
-{{- if .Values.certs.newApi }}
-apiVersion: cert-manager.io/v1alpha2
-{{- else }}
+{{- if .Values.certs.legacyApi }}
 apiVersion: certmanager.k8s.io/v1alpha1
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
 {{- end }}
 kind: Issuer
 metadata:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -49,7 +49,7 @@ terminationGracePeriodSeconds: 10
 nodeSelector: {}
 
 certs:
-  newApi: false
+  legacyApi: false
   imagePullPolicy: "IfNotPresent"
   grpc:
     create: true


### PR DESCRIPTION
Getting the `certs.newApi` value overrided was...hard. So let's fix
this properly and just accept that anyone who installs jx-app-sso at
this point needs to be on a current cert manager setup.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>